### PR TITLE
Add more ITickable variations

### DIFF
--- a/src/arp/task/ITickableElement.hx
+++ b/src/arp/task/ITickableElement.hx
@@ -1,0 +1,4 @@
+package arp.task;
+interface ITickableElement<T, T2> {
+	function tickElement(timeslice:Float, parent:T, root:T2):Bool;
+}


### PR DESCRIPTION
#19 strikes back, for `Field` - `Mortal` - `Driver` relationships